### PR TITLE
Move global Psbt fields to a Global type

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,6 +9,7 @@ macro_rules! combine {
     };
 }
 
+// Implements our Serialize/Deserialize traits using bitcoin consensus serialization.
 macro_rules! impl_psbt_de_serialize {
     ($thing:ty) => {
         impl_psbt_serialize!($thing);

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -12,6 +12,7 @@ use crate::serialize::Serialize;
 pub use self::{
     input::{Input, PsbtSighashType},
     output::Output,
+    global::Global,
 };
 
 /// A trait that describes a PSBT key-value map.

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -20,7 +20,7 @@ use bitcoin::taproot::{
 };
 use bitcoin::{ecdsa, taproot, ScriptBuf, Transaction, TxOut, VarInt, Witness};
 
-use crate::map::{Input, Map, Output, PsbtSighashType};
+use crate::map::{Global, Input, Map, Output, PsbtSighashType};
 use crate::prelude::*;
 use crate::{io, Error, Psbt};
 
@@ -50,7 +50,7 @@ impl Psbt {
 
         buf.push(0xff_u8);
 
-        buf.extend(self.serialize_map());
+        buf.extend(self.global.serialize_map());
 
         for i in &self.inputs {
             buf.extend(i.serialize_map());
@@ -77,7 +77,7 @@ impl Psbt {
 
         let mut d = bytes.get(5..).ok_or(Error::NoMorePairs)?;
 
-        let mut global = Psbt::decode_global(&mut d)?;
+        let global = Global::decode(&mut d)?;
         global.unsigned_tx_checks()?;
 
         let inputs: Vec<Input> = {
@@ -104,9 +104,7 @@ impl Psbt {
             outputs
         };
 
-        global.inputs = inputs;
-        global.outputs = outputs;
-        Ok(global)
+        Ok(Psbt { global, inputs, outputs })
     }
 }
 impl_psbt_de_serialize!(Transaction);


### PR DESCRIPTION
The PSBT conceptually has three pieces

1. The global map
2. The input map.
3. The output map.

We currently have `Input` and `Output` for the input/output maps (vectors actually) but we inline all the global map pairs into the `Psbt` struct.

As a step towards simplifying the code add a `Global` type that abstracts away all the stuff for the glabal map.