### PR TITLE
Improve code for the Combiner role

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,6 +13,25 @@ macro_rules! combine {
     };
 }
 
+/// Combines two `Option<Foo>` fields.
+///
+/// Sets `self.thing` to be `Some(other.thing)` iff `self.thing` is `None`.
+/// If `self.thing` already contains a value then this macro does nothing.
+macro_rules! combine_option {
+    ($thing:ident, $slf:ident, $other:ident) => {
+        if let (&None, Some($thing)) = (&$slf.$thing, $other.$thing) {
+            $slf.$thing = Some($thing);
+        }
+    };
+}
+
+/// Combines to `BTreeMap` fields by extending the map in `self.thing`.
+macro_rules! combine_map {
+    ($thing:ident, $slf:ident, $other:ident) => {
+        $slf.$thing.extend($other.$thing)
+    };
+}
+
 // Implements our Serialize/Deserialize traits using bitcoin consensus serialization.
 macro_rules! impl_psbt_de_serialize {
     ($thing:ty) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,18 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-/// Combines the given `$thing` field of two types by setting `self.thing` to be
-/// the value in `other.thing` iff `self.thing` is currently empty.
-///
-/// If `self.thing` already contains a value then this macro does nothing.
-#[allow(unused_macros)]
-macro_rules! combine {
-    ($thing:ident, $slf:ident, $other:ident) => {
-        if let (&None, Some($thing)) = (&$slf.$thing, $other.$thing) {
-            $slf.$thing = Some($thing);
-        }
-    };
-}
-
 /// Combines two `Option<Foo>` fields.
 ///
 /// Sets `self.thing` to be `Some(other.thing)` iff `self.thing` is `None`.

--- a/src/v0/map/global.rs
+++ b/src/v0/map/global.rs
@@ -281,8 +281,9 @@ impl Global {
             }
         }
 
-        self.proprietaries.extend(other.proprietaries);
-        self.unknowns.extend(other.unknowns);
+        combine_map!(proprietaries, self, other);
+        combine_map!(unknowns, self, other);
+
         Ok(())
     }
 }

--- a/src/v0/map/input.rs
+++ b/src/v0/map/input.rs
@@ -278,7 +278,7 @@ impl Input {
 
     /// Combines this [`Input`] with `other` `Input` (as described by BIP 174).
     pub fn combine(&mut self, other: Self) {
-        combine!(non_witness_utxo, self, other);
+        combine_option!(non_witness_utxo, self, other);
 
         if let (&None, Some(witness_utxo)) = (&self.witness_utxo, other.witness_utxo) {
             self.witness_utxo = Some(witness_utxo);

--- a/src/v0/map/input.rs
+++ b/src/v0/map/input.rs
@@ -285,25 +285,25 @@ impl Input {
             self.non_witness_utxo = None; // Clear out any non-witness UTXO when we set a witness one
         }
 
-        self.partial_sigs.extend(other.partial_sigs);
-        self.bip32_derivations.extend(other.bip32_derivations);
-        self.ripemd160_preimages.extend(other.ripemd160_preimages);
-        self.sha256_preimages.extend(other.sha256_preimages);
-        self.hash160_preimages.extend(other.hash160_preimages);
-        self.hash256_preimages.extend(other.hash256_preimages);
-        self.tap_script_sigs.extend(other.tap_script_sigs);
-        self.tap_scripts.extend(other.tap_scripts);
-        self.tap_key_origins.extend(other.tap_key_origins);
-        self.proprietaries.extend(other.proprietaries);
-        self.unknowns.extend(other.unknowns);
-
-        combine!(redeem_script, self, other);
-        combine!(witness_script, self, other);
-        combine!(final_script_sig, self, other);
-        combine!(final_script_witness, self, other);
-        combine!(tap_key_sig, self, other);
-        combine!(tap_internal_key, self, other);
-        combine!(tap_merkle_root, self, other);
+        combine_map!(partial_sigs, self, other);
+        // TODO: Why do we not combine sighash_type?
+        combine_option!(redeem_script, self, other);
+        combine_option!(witness_script, self, other);
+        combine_map!(bip32_derivations, self, other);
+        combine_option!(final_script_sig, self, other);
+        combine_option!(final_script_witness, self, other);
+        combine_map!(ripemd160_preimages, self, other);
+        combine_map!(sha256_preimages, self, other);
+        combine_map!(hash160_preimages, self, other);
+        combine_map!(hash256_preimages, self, other);
+        combine_option!(tap_key_sig, self, other);
+        combine_map!(tap_script_sigs, self, other);
+        combine_map!(tap_scripts, self, other);
+        combine_map!(tap_key_origins, self, other);
+        combine_option!(tap_internal_key, self, other);
+        combine_option!(tap_merkle_root, self, other);
+        combine_map!(proprietaries, self, other);
+        combine_map!(unknowns, self, other);
     }
 }
 

--- a/src/v0/map/output.rs
+++ b/src/v0/map/output.rs
@@ -123,15 +123,14 @@ impl Output {
 
     /// Combines this [`Output`] with `other` `Output` (as described by BIP 174).
     pub fn combine(&mut self, other: Self) {
-        self.bip32_derivations.extend(other.bip32_derivations);
-        self.proprietaries.extend(other.proprietaries);
-        self.unknowns.extend(other.unknowns);
-        self.tap_key_origins.extend(other.tap_key_origins);
-
-        combine!(redeem_script, self, other);
-        combine!(witness_script, self, other);
-        combine!(tap_internal_key, self, other);
-        combine!(tap_tree, self, other);
+        combine_option!(redeem_script, self, other);
+        combine_option!(witness_script, self, other);
+        combine_map!(bip32_derivations, self, other);
+        combine_option!(tap_internal_key, self, other);
+        combine_option!(tap_tree, self, other);
+        combine_map!(tap_key_origins, self, other);
+        combine_map!(proprietaries, self, other);
+        combine_map!(unknowns, self, other);
     }
 }
 

--- a/src/v0/mod.rs
+++ b/src/v0/mod.rs
@@ -26,11 +26,11 @@ use bitcoin::{ecdsa, Amount, ScriptBuf};
 
 use crate::error::{write_err, FeeError, FundingUtxoError};
 use crate::prelude::*;
-use crate::v0::map::Map;
+use crate::v0::map::{global, Map};
 
 #[rustfmt::skip]                // Keep pubic re-exports separate
 pub use self::{
-    error::{IndexOutOfBoundsError, SignerChecksError, SignError, CombineError, UnsignedTxChecksError, DeserializePsbtError},
+    error::{IndexOutOfBoundsError, SignerChecksError, SignError, UnsignedTxChecksError, DeserializePsbtError},
     map::{Input, Output, Global},
 };
 
@@ -170,7 +170,7 @@ impl Psbt {
     /// Combines this [`Psbt`] with `other` PSBT as described by BIP 174.
     ///
     /// In accordance with BIP 174 this function is commutative i.e., `A.combine(B) == B.combine(A)`
-    pub fn combine(&mut self, other: Self) -> Result<(), CombineError> {
+    pub fn combine(&mut self, other: Self) -> Result<(), global::CombineError> {
         self.global.combine(other.global)?;
 
         for (self_input, other_input) in self.inputs.iter_mut().zip(other.inputs.into_iter()) {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -60,6 +60,8 @@ pub use self::display_from_str::PsbtParseError;
 pub use self::miniscript::{FinalizeError, FinalizeInputError, Finalizer, InputError};
 
 /// Combines these two PSBTs as described by BIP-174 (i.e. combine is the same for BIP-370).
+///
+/// This function is commutative `combine(this, that) = combine(that, this)`.
 pub fn combine(this: Psbt, that: Psbt) -> Result<Psbt, InconsistentKeySourcesError> {
     this.combine_with(that)
 }
@@ -659,7 +661,11 @@ impl Psbt {
 
     /// Combines this [`Psbt`] with `other` PSBT as described by BIP-174.
     ///
-    /// In accordance with BIP-174 this function is commutative i.e., `A.combine(B) == B.combine(A)`.
+    /// BIP-370 does not include any additional requirements for the Combiner role.
+    ///
+    /// This function is commutative `A.combine_with(B) = B.combine_with(A)`.
+    ///
+    /// See [`combine()`] for a non-consuming version of this function.
     pub fn combine_with(mut self, other: Self) -> Result<Psbt, InconsistentKeySourcesError> {
         self.global.combine(other.global)?;
 

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -62,9 +62,7 @@ pub use self::miniscript::{FinalizeError, FinalizeInputError, Finalizer, InputEr
 /// Combines these two PSBTs as described by BIP-174 (i.e. combine is the same for BIP-370).
 ///
 /// This function is commutative `combine(this, that) = combine(that, this)`.
-pub fn combine(this: Psbt, that: Psbt) -> Result<Psbt, global::CombineError> {
-    this.combine_with(that)
-}
+pub fn combine(this: Psbt, that: Psbt) -> Result<Psbt, CombineError> { this.combine_with(that) }
 // TODO: Consider adding an iterator API that combines a list of PSBTs.
 
 /// Implements the BIP-370 Creator role.
@@ -666,11 +664,11 @@ impl Psbt {
     /// This function is commutative `A.combine_with(B) = B.combine_with(A)`.
     ///
     /// See [`combine()`] for a non-consuming version of this function.
-    pub fn combine_with(mut self, other: Self) -> Result<Psbt, global::CombineError> {
+    pub fn combine_with(mut self, other: Self) -> Result<Psbt, CombineError> {
         self.global.combine(other.global)?;
 
         for (self_input, other_input) in self.inputs.iter_mut().zip(other.inputs.into_iter()) {
-            self_input.combine(other_input);
+            self_input.combine(other_input)?;
         }
 
         for (self_output, other_output) in self.outputs.iter_mut().zip(other.outputs.into_iter()) {
@@ -1298,4 +1296,45 @@ mod display_from_str {
             }
         }
     }
+}
+
+/// Error combining two input maps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CombineError {
+    /// Error while combining the global maps.
+    Global(global::CombineError),
+    /// Error while combining the input maps.
+    Input(input::CombineError),
+}
+
+impl fmt::Display for CombineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use CombineError::*;
+
+        match *self {
+            Global(ref e) => write_err!(f, "error while combining the global maps"; e),
+            Input(ref e) => write_err!(f, "error while combining the input maps"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CombineError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use CombineError::*;
+
+        match *self {
+            Global(ref e) => Some(e),
+            Input(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<global::CombineError> for CombineError {
+    fn from(e: global::CombineError) -> Self { Self::Global(e) }
+}
+
+impl From<input::CombineError> for CombineError {
+    fn from(e: input::CombineError) -> Self { Self::Input(e) }
 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -672,7 +672,7 @@ impl Psbt {
         }
 
         for (self_output, other_output) in self.outputs.iter_mut().zip(other.outputs.into_iter()) {
-            self_output.combine(other_output);
+            self_output.combine(other_output)?;
         }
 
         Ok(self)
@@ -1306,6 +1306,8 @@ pub enum CombineError {
     Global(global::CombineError),
     /// Error while combining the input maps.
     Input(input::CombineError),
+    /// Error while combining the output maps.
+    Output(output::CombineError),
 }
 
 impl fmt::Display for CombineError {
@@ -1315,6 +1317,7 @@ impl fmt::Display for CombineError {
         match *self {
             Global(ref e) => write_err!(f, "error while combining the global maps"; e),
             Input(ref e) => write_err!(f, "error while combining the input maps"; e),
+            Output(ref e) => write_err!(f, "error while combining the output maps"; e),
         }
     }
 }
@@ -1327,6 +1330,7 @@ impl std::error::Error for CombineError {
         match *self {
             Global(ref e) => Some(e),
             Input(ref e) => Some(e),
+            Output(ref e) => Some(e),
         }
     }
 }
@@ -1337,4 +1341,8 @@ impl From<global::CombineError> for CombineError {
 
 impl From<input::CombineError> for CombineError {
     fn from(e: input::CombineError) -> Self { Self::Input(e) }
+}
+
+impl From<output::CombineError> for CombineError {
+    fn from(e: output::CombineError) -> Self { Self::Output(e) }
 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -42,7 +42,7 @@ use bitcoin::secp256k1::{Message, Secp256k1, Signing};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};
 use bitcoin::{ecdsa, transaction, Amount, Sequence, Transaction, TxOut, Txid};
 
-use crate::error::{write_err, FeeError, FundingUtxoError, InconsistentKeySourcesError};
+use crate::error::{write_err, FeeError, FundingUtxoError};
 use crate::prelude::*;
 use crate::v0;
 use crate::v2::map::{global, input, output, Map};
@@ -62,7 +62,7 @@ pub use self::miniscript::{FinalizeError, FinalizeInputError, Finalizer, InputEr
 /// Combines these two PSBTs as described by BIP-174 (i.e. combine is the same for BIP-370).
 ///
 /// This function is commutative `combine(this, that) = combine(that, this)`.
-pub fn combine(this: Psbt, that: Psbt) -> Result<Psbt, InconsistentKeySourcesError> {
+pub fn combine(this: Psbt, that: Psbt) -> Result<Psbt, global::CombineError> {
     this.combine_with(that)
 }
 // TODO: Consider adding an iterator API that combines a list of PSBTs.
@@ -666,7 +666,7 @@ impl Psbt {
     /// This function is commutative `A.combine_with(B) = B.combine_with(A)`.
     ///
     /// See [`combine()`] for a non-consuming version of this function.
-    pub fn combine_with(mut self, other: Self) -> Result<Psbt, InconsistentKeySourcesError> {
+    pub fn combine_with(mut self, other: Self) -> Result<Psbt, global::CombineError> {
         self.global.combine(other.global)?;
 
         for (self_input, other_input) in self.inputs.iter_mut().zip(other.inputs.into_iter()) {


### PR DESCRIPTION
Improve code in the `v0` and `v2`  modules for the Combiner role. Includes refactoring and bug fixes. Note that the `v2` stuff is all new and was previously just copied from `v0`.