### PR TITLE
Bump version to 0.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.0-beta.1 - 2024-02-08
+
+- Re-import all the PSBT v0 code from `rust-bitcoin` and `rust-miniscript`[#23](https://github.com/tcharding/rust-psbt/pull/23)
+- Add initial basic integration testing against Bitcoin Core [#21](https://github.com/tcharding/rust-psbt/pull/21)
+  and [#22](https://github.com/tcharding/rust-psbt/pull/22)
+
 # 0.1.0-beta.0 - 2024-02-02
 
 The initial beta release. The aim of this release is to make the new PSBT v2 API available for beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psbt-v2"
-version = "0.1.0-beta.0"
+version = "0.1.0-beta.1"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/tcharding/rust-psbt/"


### PR DESCRIPTION
Do another beta release, this time with the PSBT v0 code exactly as it is in `rust-bitcoin` and `rust-miniscript`. This allows us to help with a deprecation path for that code.