### PR TITLE
Release tracking PR: `v0.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.0 - 2024-02-08
+
+The initial non-beta release!
+
+Includes some fixes required to enable porting `bdk` to use the `v0` module.
+
 # 0.1.0-beta.1 - 2024-02-08
 
 - Re-import all the PSBT v0 code from `rust-bitcoin` and `rust-miniscript`[#23](https://github.com/tcharding/rust-psbt/pull/23)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psbt-v2"
-version = "0.1.0-beta.1"
+version = "0.1.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/tcharding/rust-psbt/"

--- a/src/v0/miniscript/finalizer.rs
+++ b/src/v0/miniscript/finalizer.rs
@@ -453,7 +453,7 @@ mod tests {
     use bitcoin::hashes::hex::FromHex;
 
     use super::*;
-    use miniscript::psbt::PsbtExt;
+    use crate::v0::miniscript::PsbtExt;
 
     #[test]
     fn tests_from_bip174() {

--- a/src/v0/miniscript/mod.rs
+++ b/src/v0/miniscript/mod.rs
@@ -15,7 +15,6 @@ use core::fmt;
 use std::error;
 
 use bitcoin::hashes::{hash160, sha256d, Hash};
-use bitcoin::psbt::{self, Psbt};
 use bitcoin::secp256k1::{self, Secp256k1, VerifyOnly};
 use bitcoin::sighash::{self, SighashCache};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapLeafHash};
@@ -26,6 +25,7 @@ use miniscript::{
     Preimage32, Satisfier, SigType, ToPublicKey, TranslatePk, Translator,
 };
 
+use crate::v0::bitcoin::{raw, Input, Output, Psbt};
 use crate::prelude::*;
 
 mod finalizer;
@@ -930,7 +930,7 @@ pub trait PsbtInputExt {
     ) -> Result<Descriptor<bitcoin::PublicKey>, descriptor::ConversionError>;
 }
 
-impl PsbtInputExt for psbt::Input {
+impl PsbtInputExt for Input {
     fn update_with_descriptor_unchecked(
         &mut self,
         descriptor: &Descriptor<DefiniteDescriptorKey>,
@@ -964,7 +964,7 @@ pub trait PsbtOutputExt {
     ) -> Result<Descriptor<bitcoin::PublicKey>, descriptor::ConversionError>;
 }
 
-impl PsbtOutputExt for psbt::Output {
+impl PsbtOutputExt for Output {
     fn update_with_descriptor_unchecked(
         &mut self,
         descriptor: &Descriptor<DefiniteDescriptorKey>,
@@ -1013,20 +1013,20 @@ trait PsbtFields {
     fn tap_key_origins(
         &mut self,
     ) -> &mut BTreeMap<bitcoin::key::XOnlyPublicKey, (Vec<TapLeafHash>, bip32::KeySource)>;
-    fn proprietary(&mut self) -> &mut BTreeMap<psbt::raw::ProprietaryKey, Vec<u8>>;
-    fn unknown(&mut self) -> &mut BTreeMap<psbt::raw::Key, Vec<u8>>;
+    fn proprietary(&mut self) -> &mut BTreeMap<raw::ProprietaryKey, Vec<u8>>;
+    fn unknown(&mut self) -> &mut BTreeMap<raw::Key, Vec<u8>>;
 
-    // `tap_tree` only appears in psbt::Output, so it's returned as an option of a mutable ref
+    // `tap_tree` only appears in Output, so it's returned as an option of a mutable ref
     fn tap_tree(&mut self) -> Option<&mut Option<taproot::TapTree>> { None }
 
-    // `tap_scripts` and `tap_merkle_root` only appear in psbt::Input
+    // `tap_scripts` and `tap_merkle_root` only appear in Input
     fn tap_scripts(&mut self) -> Option<&mut BTreeMap<ControlBlock, (ScriptBuf, LeafVersion)>> {
         None
     }
     fn tap_merkle_root(&mut self) -> Option<&mut Option<taproot::TapNodeHash>> { None }
 }
 
-impl PsbtFields for psbt::Input {
+impl PsbtFields for Input {
     fn redeem_script(&mut self) -> &mut Option<ScriptBuf> { &mut self.redeem_script }
     fn witness_script(&mut self) -> &mut Option<ScriptBuf> { &mut self.witness_script }
     fn bip32_derivation(&mut self) -> &mut BTreeMap<secp256k1::PublicKey, bip32::KeySource> {
@@ -1040,10 +1040,10 @@ impl PsbtFields for psbt::Input {
     ) -> &mut BTreeMap<bitcoin::key::XOnlyPublicKey, (Vec<TapLeafHash>, bip32::KeySource)> {
         &mut self.tap_key_origins
     }
-    fn proprietary(&mut self) -> &mut BTreeMap<psbt::raw::ProprietaryKey, Vec<u8>> {
+    fn proprietary(&mut self) -> &mut BTreeMap<raw::ProprietaryKey, Vec<u8>> {
         &mut self.proprietary
     }
-    fn unknown(&mut self) -> &mut BTreeMap<psbt::raw::Key, Vec<u8>> { &mut self.unknown }
+    fn unknown(&mut self) -> &mut BTreeMap<raw::Key, Vec<u8>> { &mut self.unknown }
 
     fn tap_scripts(&mut self) -> Option<&mut BTreeMap<ControlBlock, (ScriptBuf, LeafVersion)>> {
         Some(&mut self.tap_scripts)
@@ -1053,7 +1053,7 @@ impl PsbtFields for psbt::Input {
     }
 }
 
-impl PsbtFields for psbt::Output {
+impl PsbtFields for Output {
     fn redeem_script(&mut self) -> &mut Option<ScriptBuf> { &mut self.redeem_script }
     fn witness_script(&mut self) -> &mut Option<ScriptBuf> { &mut self.witness_script }
     fn bip32_derivation(&mut self) -> &mut BTreeMap<secp256k1::PublicKey, bip32::KeySource> {
@@ -1067,10 +1067,10 @@ impl PsbtFields for psbt::Output {
     ) -> &mut BTreeMap<bitcoin::key::XOnlyPublicKey, (Vec<TapLeafHash>, bip32::KeySource)> {
         &mut self.tap_key_origins
     }
-    fn proprietary(&mut self) -> &mut BTreeMap<psbt::raw::ProprietaryKey, Vec<u8>> {
+    fn proprietary(&mut self) -> &mut BTreeMap<raw::ProprietaryKey, Vec<u8>> {
         &mut self.proprietary
     }
-    fn unknown(&mut self) -> &mut BTreeMap<psbt::raw::Key, Vec<u8>> { &mut self.unknown }
+    fn unknown(&mut self) -> &mut BTreeMap<raw::Key, Vec<u8>> { &mut self.unknown }
 
     fn tap_tree(&mut self) -> Option<&mut Option<taproot::TapTree>> { Some(&mut self.tap_tree) }
 }
@@ -1404,10 +1404,11 @@ mod tests {
 
     use super::*;
     use miniscript::Miniscript;
+    use crate::v0::bitcoin::Psbt;
 
     #[test]
     fn test_extract_bip174() {
-        let psbt = bitcoin::Psbt::deserialize(&Vec::<u8>::from_hex("70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000107da00473044022074018ad4180097b873323c0015720b3684cc8123891048e7dbcd9b55ad679c99022073d369b740e3eb53dcefa33823c8070514ca55a7dd9544f157c167913261118c01483045022100f61038b308dc1da865a34852746f015772934208c6d24454393cd99bdf2217770220056e675a675a6d0a02b85b14e5e29074d8a25a9b5760bea2816f661910a006ea01475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae0001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e8870107232200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b20289030108da0400473044022062eb7a556107a7c73f45ac4ab5a1dddf6f7075fb1275969a7f383efff784bcb202200c05dbb7470dbf2f08557dd356c7325c1ed30913e996cd3840945db12228da5f01473044022065f45ba5998b59a27ffe1a7bed016af1f1f90d54b3aa8f7450aa5f56a25103bd02207f724703ad1edb96680b284b56d4ffcb88f7fb759eabbe08aa30f29b851383d20147522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae00220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000").unwrap()).unwrap();
+        let psbt = Psbt::deserialize(&Vec::<u8>::from_hex("70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000107da00473044022074018ad4180097b873323c0015720b3684cc8123891048e7dbcd9b55ad679c99022073d369b740e3eb53dcefa33823c8070514ca55a7dd9544f157c167913261118c01483045022100f61038b308dc1da865a34852746f015772934208c6d24454393cd99bdf2217770220056e675a675a6d0a02b85b14e5e29074d8a25a9b5760bea2816f661910a006ea01475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae0001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e8870107232200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b20289030108da0400473044022062eb7a556107a7c73f45ac4ab5a1dddf6f7075fb1275969a7f383efff784bcb202200c05dbb7470dbf2f08557dd356c7325c1ed30913e996cd3840945db12228da5f01473044022065f45ba5998b59a27ffe1a7bed016af1f1f90d54b3aa8f7450aa5f56a25103bd02207f724703ad1edb96680b284b56d4ffcb88f7fb759eabbe08aa30f29b851383d20147522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae00220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000").unwrap()).unwrap();
         let secp = Secp256k1::verification_only();
         let tx = psbt.extract(&secp).unwrap();
         let expected: bitcoin::Transaction = deserialize(&Vec::<u8>::from_hex("0200000000010258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd7500000000da00473044022074018ad4180097b873323c0015720b3684cc8123891048e7dbcd9b55ad679c99022073d369b740e3eb53dcefa33823c8070514ca55a7dd9544f157c167913261118c01483045022100f61038b308dc1da865a34852746f015772934208c6d24454393cd99bdf2217770220056e675a675a6d0a02b85b14e5e29074d8a25a9b5760bea2816f661910a006ea01475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752aeffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d01000000232200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b2028903ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f000400473044022062eb7a556107a7c73f45ac4ab5a1dddf6f7075fb1275969a7f383efff784bcb202200c05dbb7470dbf2f08557dd356c7325c1ed30913e996cd3840945db12228da5f01473044022065f45ba5998b59a27ffe1a7bed016af1f1f90d54b3aa8f7450aa5f56a25103bd02207f724703ad1edb96680b284b56d4ffcb88f7fb759eabbe08aa30f29b851383d20147522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae00000000").unwrap()).unwrap();
@@ -1421,9 +1422,9 @@ mod tests {
         let fingerprint = root_xpub.fingerprint();
         let desc = format!("tr([{}/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ/0/0)", fingerprint);
         let desc = Descriptor::from_str(&desc).unwrap();
-        let mut psbt_input = psbt::Input::default();
+        let mut psbt_input = Input::default();
         psbt_input.update_with_descriptor_unchecked(&desc).unwrap();
-        let mut psbt_output = psbt::Output::default();
+        let mut psbt_output = Output::default();
         psbt_output.update_with_descriptor_unchecked(&desc).unwrap();
         let internal_key = XOnlyPublicKey::from_str(
             "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115",
@@ -1458,9 +1459,9 @@ mod tests {
             "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115",
         )
         .unwrap();
-        let mut psbt_input = psbt::Input::default();
+        let mut psbt_input = Input::default();
         psbt_input.update_with_descriptor_unchecked(&desc).unwrap();
-        let mut psbt_output = psbt::Output::default();
+        let mut psbt_output = Output::default();
         psbt_output.update_with_descriptor_unchecked(&desc).unwrap();
         assert_eq!(psbt_input.tap_internal_key, Some(internal_key));
         assert_eq!(
@@ -1548,10 +1549,10 @@ mod tests {
             let derived = format!("wsh(multi(2,{}))", pubkeys.join(","));
             let derived = Descriptor::<bitcoin::PublicKey>::from_str(&derived).unwrap();
 
-            let mut psbt_input = psbt::Input::default();
+            let mut psbt_input = Input::default();
             psbt_input.update_with_descriptor_unchecked(&desc).unwrap();
 
-            let mut psbt_output = psbt::Output::default();
+            let mut psbt_output = Output::default();
             psbt_output.update_with_descriptor_unchecked(&desc).unwrap();
 
             assert_eq!(expected_bip32, psbt_input.bip32_derivation);
@@ -1568,10 +1569,10 @@ mod tests {
             let derived = format!("sh(multi(2,{}))", pubkeys.join(","));
             let derived = Descriptor::<bitcoin::PublicKey>::from_str(&derived).unwrap();
 
-            let mut psbt_input = psbt::Input::default();
+            let mut psbt_input = Input::default();
             psbt_input.update_with_descriptor_unchecked(&desc).unwrap();
 
-            let mut psbt_output = psbt::Output::default();
+            let mut psbt_output = Output::default();
             psbt_output.update_with_descriptor_unchecked(&desc).unwrap();
 
             assert_eq!(psbt_input.bip32_derivation, expected_bip32);


### PR DESCRIPTION
I ported `bdk` to use this (on top of an open PR to upgrade `bdk` to `rust-bitcoin v0.31.1` as a test that the recent re-import of `v0` code was correct. 

- Patch 1 is the fixes needed to get `bdk` port working.
- Patch 2 bumps the version ready for release.