### PR TITLE
[WIP] Impl conversion from v2::Psbt to v0::Psbt

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -20,8 +20,8 @@ use bitcoin::hex::DisplayHex;
 
 use crate::io::{self, BufRead, Write};
 use crate::prelude::*;
-use crate::serialize;
 use crate::serialize::{Deserialize, Serialize};
+use crate::{serialize, v0};
 
 /// A PSBT key-value pair in its raw byte form.
 ///
@@ -112,6 +112,10 @@ impl Key {
 
         Ok(Key { type_value, key })
     }
+
+    pub(crate) fn into_v0(self) -> v0::bitcoin::raw::Key {
+        v0::bitcoin::raw::Key { type_value: self.type_value, key: self.key }
+    }
 }
 
 impl Serialize for Key {
@@ -160,6 +164,14 @@ where
 {
     /// Constructs full [Key] corresponding to this proprietary key type
     pub fn to_key(&self) -> Key { Key { type_value: 0xFC, key: serialize(self) } }
+
+    pub(crate) fn into_v0(self) -> v0::bitcoin::raw::ProprietaryKey<Subtype> {
+        v0::bitcoin::raw::ProprietaryKey {
+            prefix: self.prefix,
+            subtype: self.subtype,
+            key: self.key,
+        }
+    }
 }
 
 impl<Subtype> TryFrom<Key> for ProprietaryKey<Subtype>

--- a/src/v0/bitcoin/raw.rs
+++ b/src/v0/bitcoin/raw.rs
@@ -16,6 +16,7 @@ use bitcoin::consensus::encode::{
 use super::serialize::{Deserialize, Serialize};
 use crate::io::{self, BufRead, Write};
 use crate::prelude::*;
+use crate::raw;
 use crate::v0::bitcoin::Error;
 
 /// A PSBT key in its raw byte form.
@@ -101,6 +102,10 @@ impl Key {
 
         Ok(Key { type_value, key })
     }
+}
+
+impl From<raw::Key> for Key {
+    fn from(key: raw::Key) -> Self { Key { type_value: key.type_value, key: key.key } }
 }
 
 impl Serialize for Key {
@@ -197,5 +202,14 @@ where
         }
 
         Ok(deserialize(&key.key)?)
+    }
+}
+
+impl<SubType> From<raw::ProprietaryKey<SubType>> for ProprietaryKey<SubType>
+where
+    SubType: Copy + From<u8> + Into<u8>,
+{
+    fn from(key: raw::ProprietaryKey<SubType>) -> Self {
+        ProprietaryKey::<SubType> { prefix: key.prefix, subtype: key.subtype, key: key.key }
     }
 }

--- a/src/v0/bitcoin/raw.rs
+++ b/src/v0/bitcoin/raw.rs
@@ -16,7 +16,6 @@ use bitcoin::consensus::encode::{
 use super::serialize::{Deserialize, Serialize};
 use crate::io::{self, BufRead, Write};
 use crate::prelude::*;
-use crate::raw;
 use crate::v0::bitcoin::Error;
 
 /// A PSBT key in its raw byte form.
@@ -102,10 +101,6 @@ impl Key {
 
         Ok(Key { type_value, key })
     }
-}
-
-impl From<raw::Key> for Key {
-    fn from(key: raw::Key) -> Self { Key { type_value: key.type_value, key: key.key } }
 }
 
 impl Serialize for Key {
@@ -202,14 +197,5 @@ where
         }
 
         Ok(deserialize(&key.key)?)
-    }
-}
-
-impl<SubType> From<raw::ProprietaryKey<SubType>> for ProprietaryKey<SubType>
-where
-    SubType: Copy + From<u8> + Into<u8>,
-{
-    fn from(key: raw::ProprietaryKey<SubType>) -> Self {
-        ProprietaryKey::<SubType> { prefix: key.prefix, subtype: key.subtype, key: key.key }
     }
 }

--- a/src/v2/map/input.rs
+++ b/src/v2/map/input.rs
@@ -158,13 +158,8 @@ impl Input {
 
     /// Converts this `Input` to a `v0::Input`.
     pub(crate) fn into_v0(self) -> v0::Input {
-        let proprietary = self
-            .proprietaries
-            .into_iter()
-            .map(|(k, v)| (v0::bitcoin::raw::ProprietaryKey::from(k), v))
-            .collect();
-        let unknown =
-            self.unknowns.into_iter().map(|(k, v)| (v0::bitcoin::raw::Key::from(k), v)).collect();
+        let proprietary = self.proprietaries.into_iter().map(|(k, v)| (k.into_v0(), v)).collect();
+        let unknown = self.unknowns.into_iter().map(|(k, v)| (k.into_v0(), v)).collect();
 
         v0::Input {
             non_witness_utxo: self.non_witness_utxo,

--- a/src/v2/map/input.rs
+++ b/src/v2/map/input.rs
@@ -30,7 +30,7 @@ use crate::prelude::*;
 use crate::serialize::{Deserialize, Serialize};
 use crate::sighash_type::{InvalidSighashTypeError, PsbtSighashType};
 use crate::v2::map::Map;
-use crate::{raw, serialize};
+use crate::{raw, serialize, v0};
 
 /// A key-value map for an input of the corresponding index in the unsigned
 /// transaction.
@@ -156,32 +156,40 @@ impl Input {
         }
     }
 
-    // /// Converts this `Input` to a `v0::Input`.
-    // pub(crate) fn into_v0(self) -> v0::Input {
-    //     v0::Input {
-    //         non_witness_utxo: self.non_witness_utxo,
-    //         witness_utxo: self.witness_utxo,
-    //         partial_sigs: self.partial_sigs,
-    //         sighash_type: self.sighash_type,
-    //         redeem_script: self.redeem_script,
-    //         witness_script: self.witness_script,
-    //         bip32_derivation: self.bip32_derivations,
-    //         final_script_sig: self.final_script_sig,
-    //         final_script_witness: self.final_script_witness,
-    //         ripemd160_preimages: self.ripemd160_preimages,
-    //         sha256_preimages: self.sha256_preimages,
-    //         hash160_preimages: self.hash160_preimages,
-    //         hash256_preimages: self.hash256_preimages,
-    //         tap_key_sig: self.tap_key_sig,
-    //         tap_script_sigs: self.tap_script_sigs,
-    //         tap_scripts: self.tap_scripts,
-    //         tap_key_origins: self.tap_key_origins,
-    //         tap_internal_key: self.tap_internal_key,
-    //         tap_merkle_root: self.tap_merkle_root,
-    //         proprietary: self.proprietaries,
-    //         unknown: self.unknowns,
-    //     }
-    // }
+    /// Converts this `Input` to a `v0::Input`.
+    pub(crate) fn into_v0(self) -> v0::Input {
+        let proprietary = self
+            .proprietaries
+            .into_iter()
+            .map(|(k, v)| (v0::bitcoin::raw::ProprietaryKey::from(k), v))
+            .collect();
+        let unknown =
+            self.unknowns.into_iter().map(|(k, v)| (v0::bitcoin::raw::Key::from(k), v)).collect();
+
+        v0::Input {
+            non_witness_utxo: self.non_witness_utxo,
+            witness_utxo: self.witness_utxo,
+            partial_sigs: self.partial_sigs,
+            sighash_type: self.sighash_type,
+            redeem_script: self.redeem_script,
+            witness_script: self.witness_script,
+            bip32_derivation: self.bip32_derivations,
+            final_script_sig: self.final_script_sig,
+            final_script_witness: self.final_script_witness,
+            ripemd160_preimages: self.ripemd160_preimages,
+            sha256_preimages: self.sha256_preimages,
+            hash160_preimages: self.hash160_preimages,
+            hash256_preimages: self.hash256_preimages,
+            tap_key_sig: self.tap_key_sig,
+            tap_script_sigs: self.tap_script_sigs,
+            tap_scripts: self.tap_scripts,
+            tap_key_origins: self.tap_key_origins,
+            tap_internal_key: self.tap_internal_key,
+            tap_merkle_root: self.tap_merkle_root,
+            proprietary,
+            unknown,
+        }
+    }
 
     /// Creates a new finalized input.
     ///

--- a/src/v2/map/output.rs
+++ b/src/v2/map/output.rs
@@ -74,13 +74,8 @@ impl Output {
 
     /// Converts this `Output` to a `v0::Output`.
     pub(crate) fn into_v0(self) -> v0::Output {
-        let proprietary = self
-            .proprietaries
-            .into_iter()
-            .map(|(k, v)| (v0::bitcoin::raw::ProprietaryKey::from(k), v))
-            .collect();
-        let unknown =
-            self.unknowns.into_iter().map(|(k, v)| (v0::bitcoin::raw::Key::from(k), v)).collect();
+        let proprietary = self.proprietaries.into_iter().map(|(k, v)| (k.into_v0(), v)).collect();
+        let unknown = self.unknowns.into_iter().map(|(k, v)| (k.into_v0(), v)).collect();
 
         v0::Output {
             redeem_script: self.redeem_script,

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -44,6 +44,7 @@ use bitcoin::{ecdsa, transaction, Amount, Sequence, Transaction, TxOut, Txid};
 use crate::error::{write_err, FeeError, FundingUtxoError};
 use crate::prelude::*;
 use crate::v2::map::Map;
+use crate::{v0, Version};
 
 #[rustfmt::skip]                // Keep public exports separate.
 #[doc(inline)]
@@ -404,18 +405,37 @@ impl Updater {
         Ok(self)
     }
 
-    // /// Converts the inner PSBT v2 to a PSBT v0.
-    // pub fn into_psbt_v0(self) -> v0::Psbt {
-    //     let unsigned_tx =
-    //         self.0.unsigned_tx().expect("Updater guarantees lock time can be determined");
-    //     let psbt = self.psbt();
+    /// Converts the inner PSBT v2 to a PSBT v0.
+    pub fn into_psbt_v0(self) -> v0::Psbt {
+        let unsigned_tx =
+            self.0.unsigned_tx().expect("Updater guarantees lock time can be determined");
+        let inputs = self.0.inputs.into_iter().map(|input| input.into_v0()).collect();
+        let outputs = self.0.outputs.into_iter().map(|output| output.into_v0()).collect();
+        let proprietary = self
+            .0
+            .global
+            .proprietaries
+            .into_iter()
+            .map(|(k, v)| (v0::bitcoin::raw::ProprietaryKey::from(k), v))
+            .collect();
+        let unknown = self
+            .0
+            .global
+            .unknowns
+            .into_iter()
+            .map(|(k, v)| (v0::bitcoin::raw::Key::from(k), v))
+            .collect();
 
-    //     let global = psbt.global.into_v0(unsigned_tx);
-    //     let inputs = psbt.inputs.into_iter().map(|input| input.into_v0()).collect();
-    //     let outputs = psbt.outputs.into_iter().map(|output| output.into_v0()).collect();
-
-    //     v0::Psbt { global, inputs, outputs }
-    // }
+        v0::Psbt {
+            unsigned_tx,
+            inputs,
+            outputs,
+            version: Version::ZERO.to_u32(),
+            xpub: self.0.global.xpubs,
+            proprietary,
+            unknown,
+        }
+    }
 
     /// Returns the inner [`Psbt`].
     pub fn psbt(self) -> Psbt { self.0 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -411,20 +411,9 @@ impl Updater {
             self.0.unsigned_tx().expect("Updater guarantees lock time can be determined");
         let inputs = self.0.inputs.into_iter().map(|input| input.into_v0()).collect();
         let outputs = self.0.outputs.into_iter().map(|output| output.into_v0()).collect();
-        let proprietary = self
-            .0
-            .global
-            .proprietaries
-            .into_iter()
-            .map(|(k, v)| (v0::bitcoin::raw::ProprietaryKey::from(k), v))
-            .collect();
-        let unknown = self
-            .0
-            .global
-            .unknowns
-            .into_iter()
-            .map(|(k, v)| (v0::bitcoin::raw::Key::from(k), v))
-            .collect();
+        let proprietary =
+            self.0.global.proprietaries.into_iter().map(|(k, v)| (k.into_v0(), v)).collect();
+        let unknown = self.0.global.unknowns.into_iter().map(|(k, v)| (k.into_v0(), v)).collect();
 
         v0::Psbt {
             unsigned_tx,


### PR DESCRIPTION
Close #31 

I implemented both `From<raw::Key>` and `raw::Key::into_v0` in the first and second commits respectively. Let me know which design you think makes more sense, I tend to lean to the former but I wanted to show both to make a fully informed decision.

